### PR TITLE
Add a "no-min" task which won't minify assets.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,9 +11,6 @@ module.exports = function(grunt) {
 					// Copy all (non hidden) files (not directories) from src
 					{dest: 'dist/', src: '*', filter: 'isFile', expand: true, cwd: 'src/'},
 
-					// Copy the following hidden files
-					{dest: 'dist/.htaccess', src: 'src/.htaccess'},
-
 					// Copy any JavaScript libs
 					{dest: 'dist/', src: 'js/vendor/*.min.js', expand: true, cwd: 'src/'},
 


### PR DESCRIPTION
This should make things easier when debugging.

There might be a simpler/better way for this, but this seems to do the job.
