### PR TITLE
Enable clean-css `removeEmpty` option.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,7 @@ module.exports = function(grunt) {
 			compress: {
 				options: {
 					keepSpecialComments: 0,
+					removeEmpty: 1,
 					report: 'min'
 				},
 				files: {


### PR DESCRIPTION
Without `removeEmpty` : 42728 bytes.
With `removeEmpty`    : 42579 bytes.
