### PR TITLE
Use the npm hostname from the config file in links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .idea
 config/runtime.json
 dist
-tmp
 node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,8 +36,7 @@ module.exports = function(grunt) {
 				},
 				files: [
 					{src: '*.html', dest: 'dist/', expand: true, cwd: 'src/'},
-					{src: 'inc/*.html', dest: 'dist/', expand: true, cwd: 'src/'},
-					{src: 'js/**/*', dest: 'tmp/', expand: true, cwd: 'src/'}
+					{src: 'inc/*.html', dest: 'dist/', expand: true, cwd: 'src/'}
 				]
 			}
 		},
@@ -53,7 +52,7 @@ module.exports = function(grunt) {
 
 		browserify: {
 			dist: {
-				files: {'dist/js/bundle-<%= pkg.version %>.js': 'tmp/js/main.js'},
+				files: {'dist/js/bundle-<%= pkg.version %>.js': 'src/js/main.js'},
 				options: {transform: ['brfs']}
 			}
 		},

--- a/src/inc/config-npmsite.html
+++ b/src/inc/config-npmsite.html
@@ -1,0 +1,1 @@
+@@npmsite

--- a/src/js/david.js
+++ b/src/js/david.js
@@ -4,6 +4,8 @@ var d3 = require('d3');
 var fs = require('fs');
 var Handlebars = require('handlebars');
 
+var npmsite = fs.readFileSync(__dirname + '/../../dist/inc/config-npmsite.html');
+
 var david = {};
 
 /* d3 dependency count graph */
@@ -62,7 +64,7 @@ $('#dependency-counts-graph').each(function () {
 			.attr('transform', function () {
 				return 'translate(' + diameter / 2 + ',' + diameter / 2 + ')';
 			}).on('click', function(d) {
-				window.location = '@@npmsite/package/' + d.depName;
+				window.location = npmsite + '/package/' + d.depName;
 			});
 
 		nodeEnter.append('title').text(function(d) {


### PR DESCRIPTION
I've decided to execute the `includereplace` Grunt task against the compiled `bundle.js` file.

The other option would have been execute the task against all the raw JS files (before the browserify process). Then the transformed files would have to be stored in a temporary location, which IMO adds more complexity.

However, let me know if you prefer this second option and I'll modify the PR
