### PR TITLE
Update to github-url 1.1.0

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -38,7 +38,7 @@ function getUserRepo (modName, cb) {
 			return cb(new Error(modName + ' has no repository information'));
 		}
 
-		var info = githubUrl(repo);
+		var info = githubUrl(repo, config.github.host);
 
 		if (!info) {
 			return cb(new Error('Unsupported repository URL'));

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "~3.4.7",
     "extract": "~1.0.0",
     "github": "~0.1.12",
-    "github-url": "~1.0.0",
+    "github-url": "~1.1.0",
     "handlebars": "~1.3.0",
     "memory-cache": "~0.0.5",
     "merge": "~1.1.2",


### PR DESCRIPTION
The new version supports github enterprise hostnames
