### PR TITLE
Restore couchwatch caller arguments

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -3,7 +3,7 @@ var events = require('events');
 var config = require('config');
 
 var registry = new events.EventEmitter();
-var watcher = couchwatch(config.npm.options.registry);
+var watcher = couchwatch(config.npm.options.registry, -1);
 
 watcher.on('row', function (change) {
 	registry.emit('change', change);


### PR DESCRIPTION
They were modified by mistake in https://github.com/alanshaw/david-www/commit/9b064e5e9bea75cab3022ce1171751205707b8b5
