### PR TITLE
Use `https` for npmjs.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ___
 
 Node.js based web service that tells you when your project npm dependencies are out of date.
-To use David, your project must include a [package.json](https://npmjs.org/doc/json.html)
+To use David, your project must include a [package.json](https://www.npmjs.org/doc/files/package.json.html)
 file in the root of your repository.
 
 Currently David works with package.json files found in __public__ github repositories only.

--- a/config/default.json
+++ b/config/default.json
@@ -17,7 +17,7 @@
     "token": null
   },
   "npm": {
-    "hostname": "http://npmjs.org",
+    "hostname": "https://www.npmjs.org",
     "options": {
       "registry": "http://registry.npmjs.org"
     },


### PR DESCRIPTION
Fixes #155.

/CC @alanshaw 
