### PR TITLE
Add devDependencies to profile

### DIFF
--- a/src/css/320.less
+++ b/src/css/320.less
@@ -711,7 +711,7 @@ ul.stats {
   .avatar {
     max-width: 10%;
   }
-  .border-list li a:last-child {
+  .border-list li a:not(:first-child) {
     float: right;
     margin-right: 1em;
   }

--- a/src/profile.html
+++ b/src/profile.html
@@ -14,6 +14,7 @@
     {{#each repos}}
     <li class="{{info.status}}">
       <a href="/{{../user}}/{{repo.name}}">{{#if manifest.name}}{{manifest.name}}{{else}}{{repo.name}}{{/if}}</a>
+      <a href="/{{../user}}/{{repo.name}}/dev-status"><img src="/{{../user}}/{{repo.name}}/dev-status.svg?style=flat" alt="devDependency status"></a>
       <a href="/{{../user}}/{{repo.name}}"><img src="/{{../user}}/{{repo.name}}.svg?style=flat" alt="Dependency status"></a>
     </li>
     {{/each}}


### PR DESCRIPTION
It would be great to get an overview of a users projects `devDependencies` in a single view (example in PR), as this is frequently used.

I'm not sure if you'd need a different info.status class, or perhaps multi row layout. Let me know your thoughts, I'm happy to help with the implementation.
