### PR TITLE
Fix broken devDependencies link on profile page

### DIFF
--- a/src/profile.html
+++ b/src/profile.html
@@ -14,7 +14,7 @@
     {{#each repos}}
     <li class="{{info.status}}">
       <a href="/{{../user}}/{{repo.name}}">{{#if manifest.name}}{{manifest.name}}{{else}}{{repo.name}}{{/if}}</a>
-      <a href="/{{../user}}/{{repo.name}}/dev-status"><img src="/{{../user}}/{{repo.name}}/dev-status.svg" alt="devDependency status"></a>
+      <a href="/{{../user}}/{{repo.name}}#info=devDependencies"><img src="/{{../user}}/{{repo.name}}/dev-status.svg" alt="devDependency status"></a>
       <a href="/{{../user}}/{{repo.name}}"><img src="/{{../user}}/{{repo.name}}.svg" alt="Dependency status"></a>
     </li>
     {{/each}}


### PR DESCRIPTION
The devDependencies on the profile page gives a 404, this PR fixes the broken link to correctly link to devDependencies for the given module