### PR TITLE
Fix link to github branch/tag

### DIFF
--- a/public/status.html
+++ b/public/status.html
@@ -7,7 +7,7 @@
   <div id="repo" data-user="{{user}}" data-repo="{{repo}}" data-ref="{{ref}}">
     <h1>
       <a href="@@githubsite/{{user}}">{{user}}</a> -
-      <a href="@@githubsite/{{user}}/{{repo}}{{ref}}">{{manifest.name}}</a>
+      <a href="@@githubsite/{{user}}/{{repo}}{{#if ref}}/tree{{ref}}{{/if}}">{{manifest.name}}</a>
       <span>{{manifest.version}}{{#if manifest.ref}} <span id="branch"><i class="fa fa-code-fork"></i> {{manifest.ref}}</span>{{/if}}</span>
       <a id="status" class="badge" href="#badge-embed" title="Get badge embed code"><img src="/{{user}}/{{repo}}{{ref}}.svg" alt="Dependency status"></a>
       {{#if manifest.devDependencies}}


### PR DESCRIPTION
The link to the GitHub branch or tag is missing in the [status page](https://david-dm.org/alanshaw/david/master).

https://github.com/alanshaw/david/master : 404
https://github.com/alanshaw/david/tree/master : Correct :smile: