### PR TITLE
Allow to override github port in config

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -4,6 +4,7 @@ var GitHubApi = require("github")
 var apiOptions = {
   protocol: config.github.api.protocol,
   host: config.github.api.host,
+  port: config.github.api.port,
   version: config.github.api.version,
   pathPrefix: config.github.api.pathPrefix,
   timeout: 5000


### PR DESCRIPTION
This makes it possible pass a specific port to the github module. Currently, it fallbacks on 443 port.