### PR TITLE
added npm-shrinkwrap.json support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ config/runtime.json
 data/
 dist/
 node_modules/
+.idea/
 npm-debug.log

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -50,7 +50,7 @@ exports.getManifest = function (user, repo, ref, authToken, cb) {
 
     batch.push(batchKey, cb)
 
-    var opts = {user: user, repo: repo, path: "package.json"}
+    var opts = {user: user, repo: repo, path: "npm-shrinkwrap.json"}
 
     // Add "ref" options if ref is set. Otherwise use default branch.
     if (ref) {
@@ -58,105 +58,145 @@ exports.getManifest = function (user, repo, ref, authToken, cb) {
     }
 
     gh.repos.getContent(opts, function (er, resp) {
-      if (er) {
-        console.error("Failed to get package.json", user, repo, ref, er)
-        return batch.call(batchKey, function (cb) { cb(er) })
+
+      var shrinkwrap = null
+
+      if (resp) {
+
+        try {
+          // JSON.parse will barf with a SyntaxError if the body is ill.
+          shrinkwrap = JSON.parse(new Buffer(resp.content, resp.encoding))
+        } catch (er) {
+          console.error("Failed to parse npm-shrinkwrap.json", resp)
+          return batch.call(batchKey, function (cb) {
+            cb(new Error("Failed to parse npm-shrinkwrap.json: " + (resp && resp.content)))
+          })
+        }
       }
 
-      if (manifest && manifest.expires > Date.now()) {
-        console.log("Using cached private manifest", manifest.data.name, manifest.data.version, ref)
-        return batch.call(batchKey, function (cb) {
-          cb(null, manifest.data)
-        })
+      var opts = {user: user, repo: repo, path: "package.json"}
+
+      // Add "ref" options if ref is set. Otherwise use default branch.
+      if (ref) {
+        opts.ref = ref
       }
 
-      var data
-
-      try {
-        // JSON.parse will barf with a SyntaxError if the body is ill.
-        data = JSON.parse(new Buffer(resp.content, resp.encoding))
-      } catch (er) {
-        console.error("Failed to parse package.json", resp)
-        return batch.call(batchKey, function (cb) {
-          cb(new Error("Failed to parse package.json: " + (resp && resp.content)))
-        })
-      }
-
-      if (!data) {
-        console.error("Empty package.json")
-        return batch.call(batchKey, function (cb) {
-          cb(new Error("Empty package.json"))
-        })
-      }
-
-      console.log("Got manifest", data.name, data.version, ref)
-
-      if (!authToken) {
-        // There was no authToken so MUST be public
-        onGetRepo(null, {"private": false})
-      } else {
-        // Get repo info so we can determine private/public status
-        gh.repos.get({user: user, repo: repo}, onGetRepo)
-      }
-      
-      function onGetRepo (er, repoData) {
+      gh.repos.getContent(opts, function (er, resp) {
         if (er) {
-          console.error("Failed to get repo data", user, repo, er)
-          return batch.call(batchKey, function (cb) { cb(er) })
+          console.error("Failed to get package.json", user, repo, ref, er)
+          return batch.call(batchKey, function (cb) {
+            cb(er)
+          })
         }
 
-        var oldManifest = manifest
-
-        data.ref = ref
-        manifest = new Manifest(data, repoData.private)
-
-        db.put(manifestKey, manifest, function (er) {
-          if (er) {
-            console.error("Failed to save manifest", manifestKey, er)
-            return batch.call(batchKey, function (cb) { cb(er) })
-          }
-
-          console.log("Cached at", manifestKey);
-          
-          batch.call(batchKey, function (cb) {
+        if (manifest && manifest.expires > Date.now()) {
+          console.log("Using cached private manifest", manifest.data.name, manifest.data.version, ref)
+          return batch.call(batchKey, function (cb) {
             cb(null, manifest.data)
           })
+        }
 
-          if (!oldManifest) {
-            exports.emit("retrieve", manifest.data, user, repo, repoData.private)
-          } else {
+        var data
 
-            var oldDependencies = oldManifest ? oldManifest.data.dependencies : {}
-              , oldDevDependencies = oldManifest ? oldManifest.data.devDependencies : {}
-              , oldPeerDependencies = oldManifest ? oldManifest.data.peerDependencies : {}
-              , oldOptionalDependencies = oldManifest ? oldManifest.data.optionalDependencies : {}
+        try {
+          // JSON.parse will barf with a SyntaxError if the body is ill.
+          data = JSON.parse(new Buffer(resp.content, resp.encoding))
+        } catch (er) {
+          console.error("Failed to parse package.json", resp)
+          return batch.call(batchKey, function (cb) {
+            cb(new Error("Failed to parse package.json: " + (resp && resp.content)))
+          })
+        }
 
-            var diffs = depDiff(oldDependencies, data.dependencies)
+        if (!data) {
+          console.error("Empty package.json")
+          return batch.call(batchKey, function (cb) {
+            cb(new Error("Empty package.json"))
+          })
+        }
 
-            if (diffs.length) {
-              exports.emit("dependenciesChange", diffs, manifest.data, user, repo, repoData.private)
-            }
+        if (shrinkwrap) {
+          // merge shrinkwrap information into data
+          var dependencyNames = Object.getOwnPropertyNames(shrinkwrap.dependencies)
 
-            diffs = depDiff(oldDevDependencies, data.devDependencies)
+          dependencyNames.forEach(function (dependency) {
+            data.dependencies[dependency] = shrinkwrap.dependencies[dependency].version
+          })
+        }
 
-            if (diffs.length) {
-              exports.emit("devDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
-            }
+        console.log("Got manifest", data.name, data.version, ref)
 
-            diffs = depDiff(oldPeerDependencies, data.peerDependencies)
+        if (!authToken) {
+          // There was no authToken so MUST be public
+          onGetRepo(null, {"private": false})
+        } else {
+          // Get repo info so we can determine private/public status
+          gh.repos.get({user: user, repo: repo}, onGetRepo)
+        }
 
-            if (diffs.length) {
-              exports.emit("peerDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
-            }
-
-            diffs = depDiff(oldOptionalDependencies, data.optionalDependencies)
-
-            if (diffs.length) {
-              exports.emit("optionalDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
-            }
+        function onGetRepo(er, repoData) {
+          if (er) {
+            console.error("Failed to get repo data", user, repo, er)
+            return batch.call(batchKey, function (cb) {
+              cb(er)
+            })
           }
-        })
-      }
+
+          var oldManifest = manifest
+
+          data.ref = ref
+          manifest = new Manifest(data, repoData.private)
+
+          db.put(manifestKey, manifest, function (er) {
+            if (er) {
+              console.error("Failed to save manifest", manifestKey, er)
+              return batch.call(batchKey, function (cb) {
+                cb(er)
+              })
+            }
+
+            console.log("Cached at", manifestKey);
+
+            batch.call(batchKey, function (cb) {
+              cb(null, manifest.data)
+            })
+
+            if (!oldManifest) {
+              exports.emit("retrieve", manifest.data, user, repo, repoData.private)
+            } else {
+
+              var oldDependencies = oldManifest ? oldManifest.data.dependencies : {}
+                  , oldDevDependencies = oldManifest ? oldManifest.data.devDependencies : {}
+                  , oldPeerDependencies = oldManifest ? oldManifest.data.peerDependencies : {}
+                  , oldOptionalDependencies = oldManifest ? oldManifest.data.optionalDependencies : {}
+
+              var diffs = depDiff(oldDependencies, data.dependencies)
+
+              if (diffs.length) {
+                exports.emit("dependenciesChange", diffs, manifest.data, user, repo, repoData.private)
+              }
+
+              diffs = depDiff(oldDevDependencies, data.devDependencies)
+
+              if (diffs.length) {
+                exports.emit("devDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
+              }
+
+              diffs = depDiff(oldPeerDependencies, data.peerDependencies)
+
+              if (diffs.length) {
+                exports.emit("peerDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
+              }
+
+              diffs = depDiff(oldOptionalDependencies, data.optionalDependencies)
+
+              if (diffs.length) {
+                exports.emit("optionalDependenciesChange", diffs, manifest.data, user, repo, repoData.private)
+              }
+            }
+          })
+        }
+      })
     })
   })
 }


### PR DESCRIPTION
Hello,

I'm making heavy use of [npm shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) and I wanted to enable the tool to take it into account - some of my packages have dependencies defined with `*` to always be up to date on `npm update`.
The used version is then pinned down automatcally on release by [gulp-shrinkwrap](https://www.npmjs.com/package/gulp-shrinkwrap).

Problem was that David wasn't showing the correct information because only interpreting the `*`version, over time it would not have shown deprecated dependencies...

Due to the new depth level in the code, the diff is not shown useful data: I have commented the real new lines