### PR TITLE
Remove github.com references

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
 
     // Lint the server JavaScript
     jshint: {
-      files: ["*.js", "public/js/*.js", "!public/js/plugins.js", "test/*.js"],
+      files: ["*.js", "public/js/*.js", "!public/js/plugins.js", "test/*.js", "!config.js"],
       options: {
         jshintrc: ".jshintrc"
       }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ module.exports.generateNonce = function (length) {
 
 module.exports.requestAccessToken = function (code, cb) {
   var tokenRequest = {
-    url: "https://github.com/login/oauth/access_token",
+    url: config.github.protocol + "://" + config.github.host + "/login/oauth/access_token",
     json: {
       client_id: config.github.oauth.id,
       client_secret: config.github.oauth.secret,

--- a/public/401.html
+++ b/public/401.html
@@ -56,7 +56,7 @@
     <h1>Access Denied</h1>
     <p>Either your authentication attempt failed, or you need to authenticate.</p>
     <p>To use David with private repos,
-        <a href="https://github.com/login/oauth/authorize?client_id={{oauthClient}}&state={{csrfToken}}&scope=repo,user:email">sign in with GitHub</a>.
+        <a href="@@githubsite/login/oauth/authorize?client_id={{config.github.oauth.id}}&state={{csrfToken}}&scope=repo,user:email">sign in with GitHub</a>.
     </p>
 </body>
 </html>

--- a/public/inc/top.html
+++ b/public/inc/top.html
@@ -28,7 +28,7 @@
       <a class="auth">Signed in <i class="fa fa-github"></i></a>
     {{else}}
       {{#if config.github.oauth.id }}
-        <a class="auth" href="https://github.com/login/oauth/authorize?client_id={{config.github.oauth.id}}&state={{csrfToken}}&scope=repo,user:email">Sign in <i class="fa fa-github"></i></a>
+        <a class="auth" href="@@githubsite/login/oauth/authorize?client_id={{config.github.oauth.id}}&state={{csrfToken}}&scope=repo,user:email">Sign in <i class="fa fa-github"></i></a>
       {{else}}
         <a class="auth">Signed in <i class="fa fa-github"></i></a>
       {{/if}}


### PR DESCRIPTION
In order to make david work on GitHub Enterprise I had to remove all cases where github.com was referenced. This occurred in the 401 and top templates. The access token URL was also hard coded to github.com.

Additionally this should fix your build as config.js is now ignored by jshint.