### PR TITLE
Bypass cache for logged in status

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -27,7 +27,15 @@ function Manifest (data, priv) {
 
 Manifest.TTL = moment.duration({hours: 1})
 
-exports.getManifest = function (user, repo, path, ref, authToken, cb) {
+exports.getManifest = function (user, repo, path, ref, authToken, opts, cb) {
+  // Allow callback to be passed as third parameter
+  if (!cb) {
+    cb = opts
+    opts = {}
+  } else {
+    opts = opts || {}
+  }
+
   var manifestKey = 'manifest/' + user + '/' + repo
 
   if (path && path[path.length - 1] === '/') {
@@ -43,7 +51,7 @@ exports.getManifest = function (user, repo, path, ref, authToken, cb) {
   db.get(manifestKey, function (err, manifest) {
     if (err && !err.notFound) return cb(err)
 
-    if (manifest && !manifest.private && manifest.expires > Date.now()) {
+    if (!opts.noCache && manifest && !manifest.private && manifest.expires > Date.now()) {
       console.log('Using cached manifest', manifestKey, manifest.data.name, manifest.data.version)
       return cb(null, JSON.parse(JSON.stringify(manifest.data)))
     }
@@ -57,20 +65,20 @@ exports.getManifest = function (user, repo, path, ref, authToken, cb) {
 
     batch.push(batchKey, cb)
 
-    var opts = {user: user, repo: repo, path: (path ? path + '/' : '') + 'package.json'}
+    var ghOpts = {user: user, repo: repo, path: (path ? path + '/' : '') + 'package.json'}
 
     // Add "ref" options if ref is set. Otherwise use default branch.
     if (ref) {
-      opts.ref = ref
+      ghOpts.ref = ref
     }
 
-    gh.repos.getContent(opts, function (err, resp) {
+    gh.repos.getContent(ghOpts, function (err, resp) {
       if (err) {
         console.error('Failed to get package.json', user, repo, path, ref, err)
         return batch.call(batchKey, function (cb) { cb(err) })
       }
 
-      if (manifest && manifest.expires > Date.now()) {
+      if (!opts.noCache && manifest && manifest.expires > Date.now()) {
         console.log('Using cached private manifest', manifest.data.name, manifest.data.version, ref)
         return batch.call(batchKey, function (cb) {
           cb(null, manifest.data)

--- a/routes/helpers/with-manifest-and-info.js
+++ b/routes/helpers/with-manifest-and-info.js
@@ -19,7 +19,7 @@ module.exports = function (req, res, opts, cb) {
       return
     }
 
-    manifest.getManifest(req.params.user, req.params.repo, req.query.path, req.params.ref, authToken, function (err, manifest) {
+    manifest.getManifest(req.params.user, req.params.repo, req.query.path, req.params.ref, authToken, opts, function (err, manifest) {
       if (errors.happened(err, req, res, 'Failed to get package.json')) {
         return
       }

--- a/routes/status.js
+++ b/routes/status.js
@@ -1,7 +1,7 @@
 var withManifestAndInfo = require('./helpers/with-manifest-and-info')
 
 module.exports = function (req, res) {
-  withManifestAndInfo(req, res, function (manifest, info) {
+  withManifestAndInfo(req, res, {noCache: !!res.locals.user}, function (manifest, info) {
     res.render('status', {
       user: req.params.user,
       repo: req.params.repo,


### PR DESCRIPTION
This adds a flag to bypass the cache for logged in users when they directly view the status page.  Hopefully logged in users should be relatively low traffic and by restricting it to when they explicitly load the status page, we only refresh when we're pretty sure they're interested, vs. just viewing the repo.

[fixes #91]