### PR TITLE
Add a token to badges for private repos

### DIFF
--- a/config.js
+++ b/config.js
@@ -31,5 +31,9 @@ module.exports = require('rc')('david', {
   },
   nsp: {
     syncAdvisoriesInterval: 3600000
+  },
+  token: {
+    algorithm: 'aes-256-ctr',
+    secret: null
   }
 })

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const changelog = require('./lib/changelog')(config.github, config.npm)
 const profile = require('./lib/profile')(manifest, brains, github)
 const feed = require('./lib/feed')(npm, config.npm, config.site)
 const stats = require('./lib/stats')(registry, manifest)
+const badgeToken = require('./lib/badge-token')(config.token)
 
 const app = express()
 
@@ -49,8 +50,8 @@ routes.api.changelog(app, changelog)
 routes.api.info(app, manifest, brains)
 routes.api.graph(app, graph, manifest)
 routes.rss.feed(app, feed, manifest)
-routes.badge(app, manifest, brains)
-routes.status(app, manifest, brains)
+routes.badge(app, manifest, brains, badgeToken)
+routes.status(app, manifest, brains, badgeToken)
 routes.profile(app, profile)
 routes.homepage(app, stats)
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const changelog = require('./lib/changelog')(config.github, config.npm)
 const profile = require('./lib/profile')(manifest, brains, github)
 const feed = require('./lib/feed')(npm, config.npm, config.site)
 const stats = require('./lib/stats')(registry, manifest)
-const badgeToken = require('./lib/badge-token')(config.token)
+const badgeToken = require('./lib/badge-token')(config.token, config.github)
 
 const app = express()
 

--- a/lib/badge-token.js
+++ b/lib/badge-token.js
@@ -1,0 +1,17 @@
+const crypto = require('crypto')
+
+module.exports = tokenConfig => {
+  return {
+    enabled: !!tokenConfig.secret,
+
+    encrypt (authToken) {
+      const cipher = crypto.createCipher(tokenConfig.algorithm, tokenConfig.secret)
+      return cipher.update(authToken, 'utf8', 'hex') + cipher.final('hex')
+    },
+
+    decrypt (token) {
+      const decipher = crypto.createDecipher(tokenConfig.algorithm, tokenConfig.secret)
+      return decipher.update(token, 'hex', 'utf8') + decipher.final('utf8')
+    }
+  }
+}

--- a/lib/badge-token.js
+++ b/lib/badge-token.js
@@ -8,21 +8,49 @@ module.exports = (tokenConfig, githubConfig) => {
   return {
     enabled: !!tokenConfig.secret,
 
-    // Get current session auth token or globally configured token
+    // Get current session auth token or globally configured token.
     getAuthToken (req, cb) {
       return req.session.get('session/access-token', (err, authToken) => {
         cb(err, authToken || githubConfig.token)
       })
     },
 
-    encrypt (authToken) {
+    computeHmac (data) {
+      return crypto.createHmac('sha256', tokenConfig.secret).update(data).digest()
+    },
+
+    cipher (data) {
       const cipher = crypto.createCipher(tokenConfig.algorithm, tokenConfig.secret)
-      return cipher.update(authToken, 'utf8', 'hex') + cipher.final('hex')
+      return Buffer.concat([cipher.update(data, 'utf8'), cipher.final()])
+    },
+
+    decipher (data) {
+      const decipher = crypto.createDecipher(tokenConfig.algorithm, tokenConfig.secret)
+      return decipher.update(data, null, 'utf8') + decipher.final('utf8')
+    },
+
+    encrypt (authToken) {
+      const encryptedAuthToken = this.cipher(authToken)
+      const hmac = this.computeHmac(encryptedAuthToken)
+      return Buffer.concat([encryptedAuthToken, hmac]).toString('base64')
     },
 
     decrypt (token) {
-      const decipher = crypto.createDecipher(tokenConfig.algorithm, tokenConfig.secret)
-      return decipher.update(token, 'hex', 'utf8') + decipher.final('utf8')
+      const buffer = new Buffer(token, 'base64')
+
+      // The HMAC is the last 32 bytes of the buffer.
+      const inputHmac = buffer.slice(-32)
+
+      // The encrypted GitHub token is everything before the HMAC.
+      const encryptedAuthToken = buffer.slice(0, -32)
+
+      const hmac = this.computeHmac(encryptedAuthToken)
+
+      if (!hmac.equals(inputHmac)) {
+        throw new Error('Invalid message authentication code')
+      }
+
+      return this.decipher(encryptedAuthToken)
     }
   }
 }

--- a/lib/badge-token.js
+++ b/lib/badge-token.js
@@ -1,8 +1,15 @@
 const crypto = require('crypto')
 
-module.exports = tokenConfig => {
+module.exports = (tokenConfig, githubConfig) => {
   return {
     enabled: !!tokenConfig.secret,
+
+    // Get current session auth token or globally configured token
+    getAuthToken (req, cb) {
+      return req.session.get('session/access-token', (err, authToken) => {
+        cb(err, authToken || githubConfig.token)
+      })
+    },
 
     encrypt (authToken) {
       const cipher = crypto.createCipher(tokenConfig.algorithm, tokenConfig.secret)

--- a/lib/badge-token.js
+++ b/lib/badge-token.js
@@ -1,6 +1,10 @@
 const crypto = require('crypto')
 
 module.exports = (tokenConfig, githubConfig) => {
+  if (tokenConfig.secret && tokenConfig.secret.length < 16) {
+    throw new Error('Token secret is too short, must be at least 128 bits')
+  }
+
   return {
     enabled: !!tokenConfig.secret,
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -99,13 +99,8 @@ module.exports = (db, registry, github, githubConfig) => {
 
         console.log('Got manifest', data.name, data.version, ref)
 
-        if (!authToken) {
-          // There was no authToken so MUST be public
-          onGetRepo(null, {'private': false})
-        } else {
-          // Get repo info so we can determine private/public status
-          gh.repos.get({user: user, repo: repo}, onGetRepo)
-        }
+        // Get repo info so we can determine private/public status
+        gh.repos.get({user: user, repo: repo}, onGetRepo)
 
         function onGetRepo (err, repoData) {
           if (err) {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -116,6 +116,7 @@ module.exports = (db, registry, github, githubConfig) => {
           const oldManifest = manifest
 
           data.ref = ref
+          data.private = data.private || repoData.private
           manifest = {
             data,
             private: repoData.private,

--- a/public/inc/embed-badge-type.html
+++ b/public/inc/embed-badge-type.html
@@ -7,24 +7,24 @@
     <option value="flat-square">Flat Square</option>
   </select>
   <div class="theme theme-svg">
-    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if path}}?path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if path}}?path={{path}}{{/if}}" alt="{{type}}Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if qs}}?{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if qs}}?{{qs}}{{/if}}" alt="{{type}}Dependency status"></a>
     <label for="{{type}}-badge-markdown-svg">Markdown</label>
-    <input id="{{type}}-badge-markdown-svg" type="text" value="[![{{type}}Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if path}}?path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies)">
+    <input id="{{type}}-badge-markdown-svg" type="text" value="[![{{type}}Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if qs}}?{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies)">
     <label for="{{type}}-badge-html-svg">HTML</label>
-    <input id="{{type}}-badge-html-svg" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if path}}?path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="{{type}}-badge-html-svg" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg{{#if qs}}?{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
   <div class="theme theme-png">
-    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if path}}?path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if path}}?path={{path}}{{/if}}" alt="{{type}}Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if qs}}?{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if qs}}?{{qs}}{{/if}}" alt="{{type}}Dependency status"></a>
     <label for="{{type}}-badge-markdown-png">Markdown</label>
-    <input id="{{type}}-badge-markdown-png" type="text" value="[![devDependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if path}}?path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies)">
+    <input id="{{type}}-badge-markdown-png" type="text" value="[![devDependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if qs}}?{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies)">
     <label for="{{type}}-badge-html-png">HTML</label>
-    <input id="{{type}}-badge-html-png" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if path}}?path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="{{type}}-badge-html-png" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.png{{#if qs}}?{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
   <div class="theme theme-flat-square">
-    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}" alt="{{type}}Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}" alt="{{type}}Dependency status"></a>
     <label for="{{type}}-badge-markdown-flat-square">Markdown</label>
-    <input id="{{type}}-badge-markdown-flat-square" type="text" value="[![{{type}}Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies)">
+    <input id="{{type}}-badge-markdown-flat-square" type="text" value="[![{{type}}Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies)">
     <label for="{{type}}-badge-html-flat-square">HTML</label>
-    <input id="{{type}}-badge-html-flat-square" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="{{type}}-badge-html-flat-square" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}#info={{type}}Dependencies&quot; title=&quot;{{type}}Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}/{{type}}-status.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
 </div>

--- a/public/inc/embed-badge.html
+++ b/public/inc/embed-badge.html
@@ -7,24 +7,24 @@
     <option value="flat-square">Flat Square</option>
   </select>
   <div class="theme theme-svg">
-    <a href="/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}}" alt="Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}.svg{{#if qs}}?{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.svg{{#if qs}}?{{qs}}{{/if}}" alt="Dependency status"></a>
     <label for="badge-markdown-svg">Markdown</label>
-    <input id="badge-markdown-svg" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}})">
+    <input id="badge-markdown-svg" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.svg{{#if qs}}?{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}})">
     <label for="badge-html-svg">HTML</label>
-    <input id="badge-html-svg" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="badge-html-svg" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.svg{{#if qs}}?{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
   <div class="theme theme-png">
-    <a href="/{{user}}/{{repo}}{{ref}}.png{{#if path}}?path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.png{{#if path}}?path={{path}}{{/if}}" alt="Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}.png{{#if qs}}?{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.png{{#if linkQs}}?{{linkQs}}{{/if}}" alt="Dependency status"></a>
     <label for="badge-markdown-png">Markdown</label>
-    <input id="badge-markdown-png" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.png{{#if path}}?path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}})">
+    <input id="badge-markdown-png" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.png{{#if qs}}?{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}})">
     <label for="badge-html-png">HTML</label>
-    <input id="badge-html-png" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.png{{#if path}}?path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="badge-html-png" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.png{{#if qs}}?{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
   <div class="theme theme-flat-square">
-    <a href="/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}" alt="Dependency status"></a>
+    <a href="/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}"><img src="/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}" alt="Dependency status"></a>
     <label for="badge-markdown-flat-square">Markdown</label>
-    <input id="badge-markdown-flat-square" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}})">
+    <input id="badge-markdown-flat-square" type="text" value="[![Dependency Status](@@hostname/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}})](@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}})">
     <label for="badge-html-flat-square">HTML</label>
-    <input id="badge-html-flat-square" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if path}}?path={{path}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if path}}&amp;path={{path}}{{/if}}&quot;/&gt;&lt;/a&gt;">
+    <input id="badge-html-flat-square" type="text" value="&lt;a href=&quot;@@hostname/{{user}}/{{repo}}{{ref}}{{#if linkQs}}?{{linkQs}}{{/if}}&quot; title=&quot;Dependency status&quot;&gt;&lt;img src=&quot;@@hostname/{{user}}/{{repo}}{{ref}}.svg?style=flat-square{{#if qs}}&amp;{{qs}}{{/if}}&quot;/&gt;&lt;/a&gt;">
   </div>
 </div>

--- a/public/js/status/index.js
+++ b/public/js/status/index.js
@@ -145,7 +145,9 @@ $('#status-page').each(function () {
 
   badges.click(function () {
     if (!$($(this).attr('href')).size()) {
-      var data = {type: $(this).data('type'), user: repo.data('user'), repo: repo.data('repo'), path: repo.data('path'), ref: repo.data('ref')}
+      var qs = $.param(JSON.parse(JSON.stringify({path: repo.data('path') || void 0, token: $(this).data('token')})))
+      var linkQs = $.param(JSON.parse(JSON.stringify({path: repo.data('path') || void 0})))
+      var data = {type: $(this).data('type'), user: repo.data('user'), repo: repo.data('repo'), ref: repo.data('ref'), qs: qs, linkQs: linkQs}
       var ct = $(data.type ? embedTmplType(data) : embedTmpl(data))
 
       $('input', ct).each(function () {

--- a/public/status.html
+++ b/public/status.html
@@ -9,15 +9,15 @@
       <a href="@@githubsite/{{user}}">{{user}}</a> -
       <a href="@@githubsite/{{user}}/{{repo}}{{#if ref}}/tree{{ref}}{{/if}}{{#if path}}{{#if ref}}{{else}}/tree/master{{/if}}/{{path}}{{/if}}">{{manifest.name}}</a>
       <span>{{manifest.version}}{{#if manifest.ref}} <span id="branch"><i class="fa fa-code-fork"></i> {{manifest.ref}}</span>{{/if}}</span>
-      <a id="status" class="badge" href="#badge-embed" title="Get badge embed code"><img src="/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}}" alt="Dependency status"></a>
+      <a id="status" class="badge" href="#badge-embed" title="Get badge embed code"{{#if manifest.private}} data-token="{{token}}"{{/if}}><img src="/{{user}}/{{repo}}{{ref}}.svg{{#if path}}?path={{path}}{{/if}}" alt="Dependency status"></a>
       {{#if manifest.devDependencies}}
-      <a id="dev-status" class="badge" href="#dev-badge-embed" title="Get dev badge embed code" data-type="dev"><img src="/{{user}}/{{repo}}{{ref}}/dev-status.svg{{#if path}}?path={{path}}{{/if}}" alt="devDependency status"></a>
+      <a id="dev-status" class="badge" href="#dev-badge-embed" title="Get dev badge embed code" data-type="dev"{{#if manifest.private}} data-token="{{token}}"{{/if}}><img src="/{{user}}/{{repo}}{{ref}}/dev-status.svg{{#if path}}?path={{path}}{{/if}}" alt="devDependency status"></a>
       {{/if}}
       {{#if manifest.peerDependencies}}
-      <a id="peer-status" class="badge" href="#peer-badge-embed" title="Get peer badge embed code" data-type="peer"><img src="/{{user}}/{{repo}}{{ref}}/peer-status.svg{{#if path}}?path={{path}}{{/if}}" alt="peerDependency status"></a>
+      <a id="peer-status" class="badge" href="#peer-badge-embed" title="Get peer badge embed code" data-type="peer"{{#if manifest.private}} data-token="{{token}}"{{/if}}><img src="/{{user}}/{{repo}}{{ref}}/peer-status.svg{{#if path}}?path={{path}}{{/if}}" alt="peerDependency status"></a>
       {{/if}}
       {{#if manifest.optionalDependencies}}
-      <a id="optional-status" class="badge" href="#optional-badge-embed" title="Get optional badge embed code" data-type="optional"><img src="/{{user}}/{{repo}}{{ref}}/optional-status.svg{{#if path}}?path={{path}}{{/if}}" alt="optionalDependency status"></a>
+      <a id="optional-status" class="badge" href="#optional-badge-embed" title="Get optional badge embed code" data-type="optional"{{#if manifest.private}} data-token="{{token}}"{{/if}}><img src="/{{user}}/{{repo}}{{ref}}/optional-status.svg{{#if path}}?path={{path}}{{/if}}" alt="optionalDependency status"></a>
       {{/if}}
     </h1>
     {{#if manifest.description}}

--- a/routes/helpers/with-manifest-and-info.js
+++ b/routes/helpers/with-manifest-and-info.js
@@ -28,7 +28,7 @@ module.exports = (manifest, brains) => {
             return
           }
 
-          cb(manifest, info)
+          cb(manifest, info, authToken)
         })
       })
     })

--- a/routes/status.js
+++ b/routes/status.js
@@ -1,15 +1,18 @@
-module.exports = (app, manifest, brains) => {
+module.exports = (app, manifest, brains, badgeToken) => {
   const withManifestAndInfo = require('./helpers/with-manifest-and-info')(manifest, brains)
 
   app.get('/:user/:repo/:ref?', (req, res) => {
-    withManifestAndInfo(req, res, {noCache: !!res.locals.user}, (manifest, info) => {
+    withManifestAndInfo(req, res, {noCache: !!res.locals.user}, (manifest, info, authToken) => {
+      const token = (manifest.private && badgeToken.enabled) ? badgeToken.encrypt(authToken) : null
+
       res.render('status', {
         user: req.params.user,
         repo: req.params.repo,
         path: req.query.path,
         ref: req.params.ref ? '/' + req.params.ref : '',
         manifest,
-        info
+        info,
+        token
       })
     })
   })

--- a/routes/status.js
+++ b/routes/status.js
@@ -2,17 +2,23 @@ module.exports = (app, manifest, brains, badgeToken) => {
   const withManifestAndInfo = require('./helpers/with-manifest-and-info')(manifest, brains)
 
   app.get('/:user/:repo/:ref?', (req, res) => {
-    withManifestAndInfo(req, res, {noCache: !!res.locals.user}, (manifest, info, authToken) => {
-      const token = (manifest.private && badgeToken.enabled) ? badgeToken.encrypt(authToken) : null
+    withManifestAndInfo(req, res, {noCache: !!res.locals.user}, (manifest, info) => {
+      badgeToken.getAuthToken(req, (err, authToken) => {
+        if (err) {
+          console.error('Failed to get session access token', err)
+        }
 
-      res.render('status', {
-        user: req.params.user,
-        repo: req.params.repo,
-        path: req.query.path,
-        ref: req.params.ref ? '/' + req.params.ref : '',
-        manifest,
-        info,
-        token
+        const token = (authToken && manifest.private && badgeToken.enabled) ? badgeToken.encrypt(authToken) : null
+
+        res.render('status', {
+          user: req.params.user,
+          repo: req.params.repo,
+          path: req.query.path,
+          ref: req.params.ref ? '/' + req.params.ref : '',
+          manifest,
+          info,
+          token
+        })
       })
     })
   })


### PR DESCRIPTION
## Issue

We can't share/embed David badges for private repos. Currently, viewing the badge for a private repo requires to be logged-in with a GitHub account that have access to the repo in question.

1. It wouldn't be a good idea to make the badges for private repos public.
1. We can't even do this technically because if the repo data is not cached or out of date, we need the GitHub token to access the private repo in order to refresh the badge.
1. Since David is "stateless" (the database is wiped on boot), there's no way to reliably persist and get the GitHub token for a private repo without being actually logged-in on a GitHub account with access to this repo.
1. Passing the GitHub token as parameter is out of question since it would give direct access to the user info and repos.

Closes #165, #176.

## Proposition

For private repos, add a `token` parameter to the badge URL. This token is the current user's GitHub token, encrypted with a secret server key provided via configuration.

### Pros

* **Stateless:** doesn't require any persistent data store to keep track of tokens.
* **Secure:** only David with the secret key can get back the GitHub token from the encrypted parameter.

### Cons

* Can't revoke a token directly. If you give a badge URL with a token to someone, the badge will always be accessible and cannot be revoked unless the GitHub OAuth token itself is revoked, or the encryption secret is changed for the whole site.

## Implementation

### Config

* Add `token.algorithm` and `token.secret` config options, algorithm defaulting to `aes-256-ctr` (which is I think a sane default), and no secret. If no secret is set, no token will be generated and the behavior will be the same as now.

### Library

* Add `lib/badge-token.js`, exposing `encrypt` and `decrypt` functions, using the config algorithm and secret, and `getAuthToken` to get a token either from the current session or the globally configured GitHub token. The `encrypt` function appends an HMAC to the generated token, and the `decrypt` function verifies it.
* Modify the manifest to ensure the `package.json` `private` key is always set (if not explicitly set, will be whether the GitHub repo is private). Allows the rest of the code to do specific actions for private repos.
* Also modify the manifest to always get repo status (to know whether it's private); indeed, even if there's no session auth token, there can be a global GitHub token configured that gives access to private repos.

### Index

* Inject `badgeToken` in `badge` and `status` routes.

### Frontend

* Modify `embed-badge*` views to take `qs` and `linkQs` variables instead of `path`. This is necessary because we need to add a `token` parameter for private repos, but since there's already a potential `path` parameter, it's more complex to add a new parameter (might need a `?` or a `&`), and I prefered to rely on `jQuery.params` and give the whole query string. But since the token is only for the image and not the link, I introduced two variables for this.
* In the status page, add a `data-token` with generated token for the badge of private repos.
* Also modify the script of the status page to pass the new query string variables to the `embed-badge*` views, using `jQuery.params`.

### Routes

* In the badge route, support `token` parameter, decrypt it to get the GitHub token and use it in place of the session token if valid.
* In the status route, for a private repo, generate the encrypted token (from session or global GitHub token, using `badgeToken.getAuthToken`) and pass it to the view.

---

**Note:** this PR pretty critical since it involves encryption and security of GitHub tokens. I'm not a cryptography expert, so if we end up going with this solution, I'd feel better having it thoroughly reviewed by someone competent, and it would maybe we wise to ping the GitHub security team at some point.