### PR TITLE
Update CMD to use npm start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:4
+FROM node:6
 
 WORKDIR /opt
 EXPOSE 1337
 VOLUME ["/opt/data"]
-CMD ["node", "index.js"]
-
-ADD package.json /opt/package.json
-RUN cd /opt && npm install
 
 ADD . /opt
+RUN npm install &&            \
+    npm run build &&          \
+    npm prune --production && \
+    npm cache clean
 
-RUN npm run build
+CMD ["npm", "start"]


### PR DESCRIPTION
This updates the Dockerfile to Node 6. Adds the updated entry point. It also attempts to keep the image size down by pruning dev dependencies after its built and cleaning the cache.