### PR TITLE
Adds GitHub API CA configuration option

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,8 @@ export default rc('david', {
       version: '3.0.0',
       protocol: 'https',
       host: 'api.github.com',
-      timeout: 5000
+      timeout: 5000,
+      caFile: null
     },
     protocol: 'https',
     host: 'github.com',

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,4 +1,5 @@
 import GitHubApi from 'github'
+import fs from 'fs'
 
 export default ({githubConfig}) => {
   const apiOpts = {
@@ -7,7 +8,8 @@ export default ({githubConfig}) => {
     port: githubConfig.api.port,
     version: githubConfig.api.version,
     pathPrefix: githubConfig.api.pathPrefix,
-    timeout: githubConfig.api.timeout
+    timeout: githubConfig.api.timeout,
+    ca: (githubConfig.api.caFile ? fs.readFileSync(githubConfig.api.caFile) : undefined)
   }
 
   const defaultInstance = new GitHubApi(apiOpts)


### PR DESCRIPTION
Passes through a CA to GitHub API for users of GitHub Enterprise with a self-signed certificate.