### PR TITLE
move to alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:6
+FROM node:6-alpine
 
 WORKDIR /opt
 EXPOSE 1337
 VOLUME ["/opt/data"]
+
+RUN apk add --no-cache make gcc g++ python
 
 ADD . /opt
 RUN npm install &&            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ WORKDIR /opt
 EXPOSE 1337
 VOLUME ["/opt/data"]
 
-RUN apk add --no-cache make gcc g++ python
-
 ADD . /opt
-RUN npm install &&            \
-    npm run build &&          \
+RUN apk add --no-cache make gcc g++ python && \
+    npm install && \
+    npm run build && \
     npm prune --production && \
-    npm cache clean
+    npm cache clean && \
+    apk del make gcc g++ python
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Relating to this issue #352, the docker image take only 348MB now.