### PR TITLE
Make it clear that you can set 'pathPrefix'

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,7 @@ export default rc('david', {
       version: '3.0.0',
       protocol: 'https',
       host: 'api.github.com',
+      pathPrefix: null,
       timeout: 5000,
       caFile: null
     },


### PR DESCRIPTION
In the doc, is say to
> see `config.js` for default configuration values

I had to read the source code to work out that you can set `pathPrefix` for the GitHub API (typically when using GHE).  Hopefully this will make it easier for the next person who wants to do that.

Testing: unit tests [run in Travis](https://travis-ci.org/blgm/david-www/builds/290196708) and manually tested by running `npm run build`, `npm start` and checking that the web server started without errors and was able to display dependency pages.