### PR TITLE
Fix advisories 500 issue

### DIFF
--- a/src/ui/components/project/dependency-table.jsx
+++ b/src/ui/components/project/dependency-table.jsx
@@ -90,7 +90,7 @@ function Advisories ({ dep }) {
     <ul className='vulns'>
       {dep.advisories.map((a) => (
         <li key={a.slug}>
-          <a href={`https://nodesecurity.io/advisories/${a.slug}`}>
+          <a href={`https://nodesecurity.io/advisories/${a.id}`}>
             <i className='fa fa-exclamation-circle' /> {a.title}
           </a>
         </li>


### PR DESCRIPTION
Currently seems nodesecurity.io advisories cannot find advisory based on the slug, instead use id, so just change slug to id for the hyperlink