### PR TITLE
Update `standard` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "babel-eslint": "^7.2.3",
     "cross-env": "^5.1.1",
     "nodemon": "^1.9.2",
-    "standard": "^10.0.2",
+    "standard": "^11.0.0",
     "tape": "^4.5.1",
     "watchify": "^3.7.0"
   },


### PR DESCRIPTION
Other modules are out of date too, but you’ve got to start somewhere...