### PR TITLE
README: remove 'gratipay' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <a href="https://travis-ci.org/alanshaw/david-www"><img src="https://travis-ci.org/alanshaw/david-www.svg" alt="Build Status"></a>
 <a href="https://david-dm.org/alanshaw/david-www"><img src="https://david-dm.org/alanshaw/david-www.svg" alt="Dependency Status"></a>
 <a href="https://david-dm.org/alanshaw/david-www/?type=dev"><img src="https://david-dm.org/alanshaw/david-www/dev-status.svg" alt="devDependency Status"></a>
-<a href="https://www.gittip.com/_alanshaw/"><img src="http://img.shields.io/gratipay/_alanshaw.svg?style=flat" alt="Donate to help support David development"></a>
 </p>
 
 Node.js based web service that tells you when your project npm dependencies are out of date.


### PR DESCRIPTION
As service is no longer available: https://gratipay.news/the-end-cbfba8f50981?gi=c1afbbcec440

Service is superseded by [Liberapay](https://gratipay.news/vive-la-liberapay-14057a25eacb)