### PR TITLE
Fix typos

### DIFF
--- a/src/lib/feed.js
+++ b/src/lib/feed.js
@@ -16,7 +16,7 @@ export default ({npm, npmConfig, siteConfig}) => {
 
       opts = opts || {}
 
-      // Assume we're probably going to have to use NPM
+      // Assume we're probably going to have to use npm
       npm.load(npmConfig.options, (err) => {
         if (err) return cb(err)
 
@@ -114,7 +114,7 @@ export default ({npm, npmConfig, siteConfig}) => {
 
 function Package (name, versions, repo) {
   this.name = name // The name of the package
-  this.versions = versions // Versions and their pubdate as returned by NPM
+  this.versions = versions // Versions and their pubdate as returned by npm
   this.repo = repo // Repository data
   this.expires = moment().add(Package.TTL) // When the versions information is considered stale
 }

--- a/src/lib/graph.js
+++ b/src/lib/graph.js
@@ -30,7 +30,7 @@ function Module ({ name, version, dependencies = [] }) {
 export default ({db, npmConfig}) => {
   const Graph = {
     /**
-     * Get dependency graph for a non-NPM project
+     * Get dependency graph for a non-npm project
      *
      * @param name
      * @param version
@@ -92,7 +92,7 @@ export default ({db, npmConfig}) => {
   }
 
   /**
-   * Get the dependency graph for a given NPM dependency name and version.
+   * Get the dependency graph for a given npm dependency name and version.
    *
    * Must be executed in `npm.load()` callback.
    *

--- a/src/ui/pages/home.jsx
+++ b/src/ui/pages/home.jsx
@@ -68,7 +68,7 @@ class Home extends Component {
           <h2>Giving you badges.</h2>
 
           <p>
-            Got a <a href='http://nodejs.org/'>Node.js</a> project? Get a badge. David is free for public projects on <a href='https://github.com/'>Github</a>.
+            Got a <a href='http://nodejs.org/'>Node.js</a> project? Get a badge. David is free for public projects on <a href='https://github.com/'>GitHub</a>.
           </p>
 
           <p>
@@ -78,13 +78,13 @@ class Home extends Component {
           <p>Type your username / repo name in below and get yours...</p>
 
           <p className='badge-maker'>
-            <strong>{this.props.config.siteUrl}/<span contentEditable className={this.state.badgeUrlClass} id='username' title='[Github username] / [repo name]' onInput={this.onBadgeInput} onKeyPress={this.onBadgeKeyPress}>username/repo</span>.svg</strong>
+            <strong>{this.props.config.siteUrl}/<span contentEditable className={this.state.badgeUrlClass} id='username' title='[GitHub username] / [repo name]' onInput={this.onBadgeInput} onKeyPress={this.onBadgeKeyPress}>username/repo</span>.svg</strong>
             <img id='badge' src={this.state.badgeSrc} alt='badge' onLoad={this.onBadgeLoad} onError={this.onBadgeError} className={this.state.badgeImgClass} />
           </p>
 
           <p>
             David is currently <em>BETA</em>, which means it may be unreliable, unavailable or not working. That said, it's already useful and we're working to make it rock solid.
-            It's all in Github so <a href='https://github.com/alanshaw/david-www'>feel free to help</a>.
+            It's all in GitHub so <a href='https://github.com/alanshaw/david-www'>feel free to help</a>.
           </p>
 
           <h2>A color full of information.</h2>
@@ -99,7 +99,7 @@ class Home extends Component {
 
           <h2>Most used dependencies</h2>
 
-          <p>These are the most used NPM dependencies based on open source GitHub projects that are using them.</p>
+          <p>These are the most used npm dependencies based on open source GitHub projects that are using them.</p>
 
           <DependencyCountsGraph />
 
@@ -132,7 +132,7 @@ class Home extends Component {
         </div>
 
         <div id='recently-updated-npm' className='box'>
-          <h2>Recently updated NPM packages</h2>
+          <h2>Recently updated npm packages</h2>
           <ul className='border-list'>
             {stats.recentlyUpdatedPackages.map(({ name, previous, version }) => {
               const url = `https://www.npmjs.com/package/${name}`

--- a/src/ui/pages/stats.jsx
+++ b/src/ui/pages/stats.jsx
@@ -36,7 +36,7 @@ class Stats extends Component {
         </div>
 
         <div id='recently-updated-npm' className='box'>
-          <h2>Recently updated NPM packages</h2>
+          <h2>Recently updated npm packages</h2>
           <ul className='border-list'>
             {stats.recentlyUpdatedPackages.map(({ name, previous, version }) => {
               const url = `https://www.npmjs.com/package/${name}`

--- a/test/feed.js
+++ b/test/feed.js
@@ -6,7 +6,7 @@ test("Test get feed for dependency with no 'time' information", (t) => {
 
   const pkgName = 'sprintf'
 
-  // Create a mock NPM
+  // Create a mock npm
   const mockNpm = {
     load (opts, cb) {
       process.nextTick(cb)
@@ -15,7 +15,7 @@ test("Test get feed for dependency with no 'time' information", (t) => {
       view (args, silent, cb) {
         process.nextTick(() => {
           if (args[0] === pkgName) {
-            // Simulate NPM response for no time information
+            // Simulate npm response for no time information
             if (args[1] === 'time') {
               cb(null, {})
               return
@@ -27,7 +27,7 @@ test("Test get feed for dependency with no 'time' information", (t) => {
             }
           }
 
-          cb(new Error(`Unexpected arguments to mock NPM view command ${args}`))
+          cb(new Error(`Unexpected arguments to mock npm view command ${args}`))
         })
       }
     }
@@ -58,7 +58,7 @@ test('Test get feed for package with invalid semver range dependency', (t) => {
 
   const pkgName = 'sprintf'
 
-  // Create a mock NPM
+  // Create a mock npm
   const mockNpm = {
     load (opts, cb) {
       process.nextTick(cb)
@@ -73,7 +73,7 @@ test('Test get feed for package with invalid semver range dependency', (t) => {
             }
           }
 
-          cb(new Error(`Unexpected arguments to mock NPM view command ${args}`))
+          cb(new Error(`Unexpected arguments to mock npm view command ${args}`))
         })
       }
     }


### PR DESCRIPTION
A few minor typo/capitalization fixes, e.g.

- `NPM` -> `npm`
- `Github` -> `GitHub`